### PR TITLE
json形式からBindingNodeへの逆変換サポートの追加

### DIFF
--- a/test/utils/BindingNodeUtilTest.php
+++ b/test/utils/BindingNodeUtilTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by Emacs24 on debian.
+ * User: haruo31
+ * Date: 14/3/30
+ * To change this template use File | Settings | File Templates.
+ */
+require_once dirname(__FILE__) . '/../test_settings.php';
+require_once dirname(__FILE__) . '/../../utils/BindingNodeUtil.php';
+
+class BindingNodeUtilTest extends PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    function testDecodeBindingTree() {
+        $expected = '[{"invocationName":"TranslationPL","serviceId":"NICTJServer","children":[]},{"invocationName":"MorphologicalAnalysisPL","serviceId":"Mecab","children":[]}]';
+        $bindingTree = BindingNodeUtil::decodeBindingTree($expected);
+        $this->assertEquals($expected, json_encode($bindingTree));
+    }
+
+    function testDecodeBindingTreeWithChildren() {
+        $expected = '[{"invocationName":"TranslationPL","serviceId":"NICTJServer","children":[{"invocationName":"BilingualDictionaryWithLongestMatchSearchPL","serviceId":"KyotoTourismDictionaryDb","children":[]}]}]';
+
+        $bindingTree = BindingNodeUtil::decodeBindingTree($expected);
+        $this->assertEquals($expected, json_encode($bindingTree));
+    }
+}

--- a/utils/BindingNodeUtil.php
+++ b/utils/BindingNodeUtil.php
@@ -1,0 +1,23 @@
+<?php
+
+class BindingNodeUtil {
+    public static function decodeBindingTree($str) {
+        $obj = json_decode($str);
+        return self::createBindingNode($obj);
+    }
+
+    private static function createBindingNode($obj) {
+        if (is_array($obj)) {
+            $children = array();
+            foreach ($obj as $c) {
+                $children[] = self::createBindingNode($c);
+            }
+            return $children;
+        }
+        $bind = new BindingNode($obj->invocationName, $obj->serviceId);
+        if (isset($obj->children) && is_array($obj->children)) {
+            $bind->setChildren(self::createBindingNode($obj->children));
+        }
+        return $bind;
+    }
+}


### PR DESCRIPTION
既に作成したjson形式のbindingTreeを直接ライブラリで扱えるよう変換ユーティリティを作成しました。
よければ追加いただければと思います。
